### PR TITLE
Update Dockerfile

### DIFF
--- a/docker-directory/Dockerfile
+++ b/docker-directory/Dockerfile
@@ -2,15 +2,23 @@ FROM codercom/code-server:4.93.1
 
 RUN sudo apt-get update
 
+RUN sudo apt-get upgrade -y
+
 RUN sudo apt-get install -y python3 python3-pip
 
-RUN pip install cdm-devkit==0.2.1 --break-system-packages
+RUN wget https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb
 
-RUN wget https://github.com/cdm-processors/cdm-devkit/releases/download/0.2.1/vscode-cdm-extension-0.2.1.vsix
+RUN sudo apt install ./jdk-21_linux-x64_bin.deb -y
 
-RUN code-server --install-extension ./vscode-cdm-extension-0.2.1.vsix
+RUN rm ./jdk-21_linux-x64_bin.deb
 
-RUN rm ./vscode-cdm-extension-0.2.1.vsix
+RUN pip install cdm-devkit==0.2.2.post0 --break-system-packages
+
+RUN wget https://github.com/cdm-processors/cdm-devkit/releases/download/0.2.2/vscode-cdm-extension-0.2.2.vsix
+
+RUN code-server --install-extension ./vscode-cdm-extension-0.2.2.vsix
+
+RUN rm ./vscode-cdm-extension-0.2.2.vsix
 
 COPY config.yaml .config/code-server/config.yaml
 


### PR DESCRIPTION
Now Dockerfile uses 2.2.0 version of cdm devkit and also uploads openjdk 21 for emulator